### PR TITLE
Replace deprecated absoluteInfluenceRect call, fixing sync error

### DIFF
--- a/RealtimeBoard.sketchplugin/Contents/Sketch/core/api.js
+++ b/RealtimeBoard.sketchplugin/Contents/Sketch/core/api.js
@@ -284,11 +284,14 @@ function Api() {
       var resourceId = context.command.valueForKey_onLayer_forPluginIdentifier(boardId, artboard, "rtb_sync");
       var originalId = context.command.valueForKey_onLayer_forPluginIdentifier("originalId", artboard, "rtb_sync");
       var objectId = [artboard objectID];
-      var absoluteInfluenceRect = [artboard absoluteInfluenceRect];
-      var xPos = absoluteInfluenceRect.origin.x;
-      var yPos = absoluteInfluenceRect.origin.y;
-      var width = absoluteInfluenceRect.size.width;
-      var height = absoluteInfluenceRect.size.height;
+      
+      const document = [artboard documentData];
+      const immutable = [artboard immutableModelObject];
+      const relativeInfluenceRect = immutable.influenceRectForBoundsInDocument(document);
+      var xPos = relativeInfluenceRect.origin.x;
+      var yPos = relativeInfluenceRect.origin.y;
+      var width = relativeInfluenceRect.size.width;
+      var height = relativeInfluenceRect.size.height;
       var centralXPos = width / 2 + xPos;
       var centralYPos = height / 2 + yPos;
       var transformationData = '\\"positionData\\":{\\"x\\": ' + centralXPos + ', \\"y\\":' + centralYPos + ' }';


### PR DESCRIPTION
Fixes at least part of https://github.com/miroapp/sketch_plugin/issues/30. I am no longer having issues pushing artboards to Miro (including with SSO authentication).

This will need a version bump, if accepted.

Known issues: This produces a sketch-rtb-error in the console per artboard uploaded. I don't know if this was an issue in previous versions of the plugin.